### PR TITLE
Automatic management of tokens for API in general

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/lib/src/misc/cookieManager.dart
+++ b/lib/src/misc/cookieManager.dart
@@ -1,0 +1,81 @@
+/*
+ *  Our own implementation of Dio cookie manger
+ *  Modified from: https://github.com/flutterchina/dio/blob/master/plugins/cookie_manager/lib/src/cookie_mgr.dart
+ *
+ *  What changed? We store cookie in baseUrl instead of full Uri to allow using
+ *  cookie across the app (with requests many different routes)
+ */
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:cookie_jar/cookie_jar.dart';
+import 'package:dio/dio.dart';
+
+/// Don't use this class in Browser environment
+class CookieManager extends Interceptor {
+  /// Cookie manager for http requests。Learn more details about
+  /// CookieJar please refer to [cookie_jar](https://github.com/flutterchina/cookie_jar)
+  final CookieJar cookieJar;
+
+  CookieManager(this.cookieJar);
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    cookieJar.loadForRequest(options.baseUrl).then((cookies) {
+      var cookie = getCookies(cookies);
+      if (cookie.isNotEmpty) {
+        options.headers[HttpHeaders.cookieHeader] = cookie;
+      }
+      handler.next(options);
+    }).catchError((e, stackTrace) {
+      var err = DioError(requestOptions: options, error: e);
+      err.stackTrace = stackTrace;
+      handler.reject(err, true);
+    });
+  }
+
+  @override
+  void onResponse(Response response, ResponseInterceptorHandler handler) {
+    _saveCookies(response)
+        .then((_) => handler.next(response))
+        .catchError((e, stackTrace) {
+      var err = DioError(requestOptions: response.requestOptions, error: e);
+      err.stackTrace = stackTrace;
+      handler.reject(err, true);
+    });
+  }
+
+  @override
+  void onError(DioError err, ErrorInterceptorHandler handler) {
+    if (err.response != null) {
+      _saveCookies(err.response!)
+          .then((_) => handler.next(err))
+          .catchError((e, stackTrace) {
+        var _err = DioError(
+          requestOptions: err.response!.requestOptions,
+          error: e,
+        );
+        _err.stackTrace = stackTrace;
+        handler.next(_err);
+      });
+    } else {
+      handler.next(err);
+    }
+  }
+
+  Future<void> _saveCookies(Response response) async {
+    var cookies = response.headers[HttpHeaders.setCookieHeader];
+
+    if (cookies != null) {
+      await cookieJar.saveFromResponse(
+        response.requestOptions.baseUrl,
+        cookies.map((str) => Cookie.fromSetCookieValue(str)).toList(),
+      );
+    }
+  }
+
+  static String getCookies(List<Cookie> cookies) {
+    return cookies.map((cookie) => '${cookie.name}=${cookie.value}').join('; ');
+  }
+}

--- a/lib/src/misc/cookieManager.dart
+++ b/lib/src/misc/cookieManager.dart
@@ -22,7 +22,7 @@ class CookieManager extends Interceptor {
 
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    cookieJar.loadForRequest(options.baseUrl).then((cookies) {
+    cookieJar.loadForRequest(options.uri).then((cookies) {
       var cookie = getCookies(cookies);
       if (cookie.isNotEmpty) {
         options.headers[HttpHeaders.cookieHeader] = cookie;
@@ -69,7 +69,7 @@ class CookieManager extends Interceptor {
 
     if (cookies != null) {
       await cookieJar.saveFromResponse(
-        response.requestOptions.baseUrl,
+        response.requestOptions.uri,
         cookies.map((str) => Cookie.fromSetCookieValue(str)).toList(),
       );
     }

--- a/lib/src/providers/feedApi.dart
+++ b/lib/src/providers/feedApi.dart
@@ -14,7 +14,7 @@ class FeedAPI {
   Future<List<FeedItem>> getFeed(ApiService api) async {
     Uri uri = Uri.http(Config.baseEndpoint!, feedListPath);
 
-    final client = api._getClientWithAuth();
+    final client = await api.getClientWithAuth();
     final data = await client.get('/feed/list', queryParameters: {}); // qs for later
 
     // NOTE: Does this catch case of empty feed list?

--- a/lib/src/providers/feedApi.dart
+++ b/lib/src/providers/feedApi.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
 
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:oneplace_illinois/src/misc/config.dart';
 import 'package:oneplace_illinois/src/misc/exceptions.dart';
 import 'package:oneplace_illinois/src/models/feedItem.dart';
@@ -13,17 +14,10 @@ class FeedAPI {
   Future<List<FeedItem>> getFeed(ApiService api) async {
     Uri uri = Uri.http(Config.baseEndpoint!, feedListPath);
 
-    final response = await api.get(uri);
-    if (response.statusCode != 200) {
-      throw HttpException(
-          response.reasonPhrase ?? response.statusCode.toString());
-    }
-    Map<String, dynamic> data = jsonDecode(response.body);
-    if (data['error'] != null) {
-      log(data.toString());
-      throw ApiException(data['error']);
-    }
+    final client = api._getClientWithAuth();
+    final data = await client.get('/feed/list', queryParameters: {}); // qs for later
 
+    // NOTE: Does this catch case of empty feed list?
     List<FeedItem> feedItems =
         data['payload'].map<FeedItem>((e) => FeedItem.fromJSON(e)).toList();
     feedItems.sort((a, b) => a.postDate.compareTo(b.postDate));

--- a/lib/src/services/api.dart
+++ b/lib/src/services/api.dart
@@ -1,45 +1,138 @@
 import 'dart:convert';
 import 'dart:developer';
+import 'dart:io';
 
-import 'package:http/http.dart';
-import 'package:http/io_client.dart';
+import 'package:cookie_jar/cookie_jar.dart';
+import 'package:dio/dio.dart';
+import 'package:dio_cookie_manager/dio_cookie_manager.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:oneplace_illinois/src/misc/config.dart';
 import 'package:oneplace_illinois/src/misc/exceptions.dart';
+import 'package:oneplace_illinois/src/misc/cookieManager.dart';
 import 'package:oneplace_illinois/src/services/firebaseAuth.dart';
 
-class ApiService extends IOClient {
-  static final _loginUri = Uri.http(Config.baseEndpoint!, '/api/v1/user/login');
-  static const _refreshCookieName = 'refresh_jwt';
+class ApiService {
+  // NOTE: Signed cookie doesn't work with HTTP request. Only works with HTTPS.
+  static final _baseUrl = Uri.https(Config.baseEndpoint!);
+
+  final Directory appDocDir = await getApplicationDocumentsDirectory();
+  String appDocPath = appDocDir.path;
+
+  static PersistCookieJar _cookieJar = PersistCookieJar(
+    ignoreExpires: false, // don't save/load expired cookies
+    storage: FileStorage(appDocPath + '/.cookies/')
+  );
+
+  final storage = new FlutterSecureStorage(); // for storing access token
 
   FirebaseAuthService _firebaseAuth;
-  String? _refreshToken;
-  String? _accessToken;
 
   ApiService({required firebaseAuth}) : this._firebaseAuth = firebaseAuth;
 
-  @override
-  Future<IOStreamedResponse> send(BaseRequest request) async {
-    if (_refreshToken == null || _accessToken == null) {
+
+  Future<Dio> _getClient() async {
+    final Dio _dio = Dio();
+
+    _dio.options.baseUrl = _baseUrl;
+    _dio.interceptors.clear();
+
+    _dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (RequestOptions options){
+        return options;
+      },
+      onResponse: (Response response) {
+        if (data['error'] != null) {
+          log(data.toString());
+          throw ApiException(data['error']);
+        }
+
+        Map<String, dynamic> data = jsonDecode(response.body);
+
+        // save access token (refresh token is auto-saved by CookieManager above)
+        if (data['payload'] && data['payload']['accessToken']) {
+          await storage.write(key: 'jwt_access', value: _accessToken);
+        }
+
+        return data;
+      },
+      onError: (DioError e) {
+        return e;
+      }
+    ));
+
+    return _dio;
+  }
+
+  Future<Dio> _getClientWithAuth() async {
+    // retrieve access token
+    String _accessToken = await storage.read(key: 'jwt_access');
+
+    if (_accessToken == null) {
+      // interceptor from _getClient() used by _login() will auto-save
+      // the new access & refresh token (for later requests) 
       await _login();
     }
 
-    request.headers.addAll({
-      'Authorization': 'Bearer ${_accessToken!}',
-      'Cookie': '$_refreshCookieName=${_refreshToken!}',
-    });
+    final Dio _dio = Dio();
 
-    return super.send(request);
+    _dio.options.baseUrl = _baseUrl;
+    _dio.interceptors.clear();
+
+    // Add cookie (refresh token) to interceptor
+    _dio.interceptors.add(CookieManager(cookieJar));
+
+    _dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (RequestOptions options) {
+        // Add access token to interceptor
+        options.headers['Authorization'] = 'Bearer ' + _accessToken;
+        return options;
+      },
+      onResponse: (Response response) {
+        Map<String, dynamic> data = jsonDecode(response.body);
+
+        if (data['error'] != null) {
+          log(data.toString());
+          throw ApiException(data['error']);
+        }
+
+        // Save access token if new one is issued from the server
+        if (data['payload'] && data['payload']['accessToken']) {
+          await storage.write(key: 'jwt_access', value: _accessToken);
+        }
+
+        // return response;
+        return data;
+      }, onError: (DioError error) async {
+        // Catch response error
+        /*
+        // When server turns 403 Unauthorized, redo firebase login
+        // (hypothetical case for the moment)
+        if (error.response?.statusCode == 403) {
+          _dio.interceptors.requestLock.lock();
+          _dio.interceptors.responseLock.lock();
+
+          RequestOptions options = error.response.request;
+          await _login(); // gets new access & refresh token
+
+          _dio.interceptors.requestLock.unlock();
+          _dio.interceptors.responseLock.unlock();
+          return _dio.request(options.path, options: options);
+        } else {
+          return error;
+        }*/
+        throw HttpException(response.reasonPhrase ?? response.statusCode.toString());
+    }));
+    return _dio;
   }
 
   Future<void> _login() async {
     var user = await _firebaseAuth.userStream.first;
-    Response response = await post(_loginUri, body: {
+
+    Dio client = _getClient();
+
+    Response response = await client.post('/user/login', data: {
       'email': user!.email,
       'token': await user.getIdToken(),
     });
-
-    var cookies = response.headers['set-cookie']!;
-    _refreshToken = cookies.split(';')[0].split('=')[1];
-    _accessToken = jsonDecode(response.body)['payload']['accessToken'];
   }
 }

--- a/lib/src/services/api.dart
+++ b/lib/src/services/api.dart
@@ -97,7 +97,7 @@ class ApiService {
 
         // Save access token if new one is issued from the server
         if (data['payload'] && data['payload']['accessToken']) {
-          await storage.write(key: 'jwt_access', value: _accessToken);
+          await storage.write(key: 'jwt_access', value: data['payload']['accessToken']);
         }
 
         // return response;

--- a/lib/src/services/api.dart
+++ b/lib/src/services/api.dart
@@ -33,7 +33,7 @@ class ApiService {
   Future<Dio> _getClient() async {
     final Dio _dio = Dio();
 
-    _dio.options.baseUrl = _baseUrl;
+    _dio.options.baseUrl = _baseUrl + '/api/v1';
     _dio.interceptors.clear();
 
     _dio.interceptors.add(InterceptorsWrapper(
@@ -75,7 +75,7 @@ class ApiService {
 
     final Dio _dio = Dio();
 
-    _dio.options.baseUrl = _baseUrl;
+    _dio.options.baseUrl = _baseUrl + '/api/v1';
     _dio.interceptors.clear();
 
     // Add cookie (refresh token) to interceptor

--- a/lib/src/services/api.dart
+++ b/lib/src/services/api.dart
@@ -52,9 +52,6 @@ class ApiService {
     _dio.interceptors.clear();
 
     _dio.interceptors.add(InterceptorsWrapper(
-      onRequest: (RequestOptions options){
-        return options;
-      },
       onResponse: (Response response) {
         if (data['error'] != null) {
           log(data.toString());
@@ -68,11 +65,8 @@ class ApiService {
           await storage.write(key: 'jwt_access', value: _accessToken);
         }
 
-        return data;
+        handler.resolve(data);
       },
-      onError: (DioError e) {
-        return e;
-      }
     ));
 
     return _dio;
@@ -97,12 +91,12 @@ class ApiService {
     _dio.interceptors.add(CookieManager(_cookieJar));
 
     _dio.interceptors.add(InterceptorsWrapper(
-      onRequest: (RequestOptions options) {
+      onRequest: (RequestOptions options, handler) {
         // Add access token to interceptor
         options.headers['Authorization'] = 'Bearer ' + _accessToken;
-        return options;
+        handler.next(options);
       },
-      onResponse: (Response response) {
+      onResponse: (Response response, handler) {
         Map<String, dynamic> data = jsonDecode(response.body);
 
         if (data['error'] != null) {
@@ -116,7 +110,7 @@ class ApiService {
         }
 
         // return response;
-        return data;
+        handler.resolve(data);
       }, onError: (DioError error) async {
         // Catch response error
         /*

--- a/lib/src/services/courseApi.dart
+++ b/lib/src/services/courseApi.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
 
+import 'package:dio/dio.dart';
 import 'package:oneplace_illinois/src/misc/config.dart';
 import 'package:oneplace_illinois/src/models/courseItem.dart';
 import 'package:oneplace_illinois/src/models/sectionItem.dart';
@@ -11,14 +12,14 @@ class CourseAPI {
   Future<List<CourseItem>?> getCourses(ApiService api, String query,
       {bool onlyCourses = false}) async {
 
-    Dio client = api._getClient();
+    Dio client = await api.getClient();
 
     // NOTE: only_courses accept boolean (prev was onlyCourses.toString())
-    final body = client.get('/course/search', queryParameters: {
+    final body = await client.get('/course/search', queryParameters: {
       'keyword': query, 'only_courses': onlyCourses
     });
 
-    List<dynamic> data = body['courses']; 
+    List<dynamic> data = body['courses'];
     List<CourseItem> courses =
         data.map((e) => CourseItem.fromJSON(e, onlyCourses)).toList();
     courses.sort((a, b) => a.compareTo([query, b]));
@@ -30,9 +31,9 @@ class CourseAPI {
     String code = codeSections[0];
     String crn = codeSections[1];
 
-    Dio client = api._getClient();
+    Dio client = await api.getClient();
 
-    final body = client.get('/section/search', queryParameters: {
+    final body = await client.get('/section/search', queryParameters: {
       'code': code, 'CRN': crn,
     });
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -78,6 +78,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
+  cookie_jar:
+    dependency: "direct main"
+    description:
+      name: cookie_jar
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
   csslib:
     dependency: transitive
     description:
@@ -92,6 +99,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.0"
   fake_async:
     dependency: transitive
     description:
@@ -181,6 +195,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.5"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.1"
   flutter_spinkit:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,7 +51,8 @@ dependencies:
   tuple: ^2.0.0
   dio: ^4.0.0
   cookie_jar: ^3.0.1
-
+    #dio_cookie_manager: ^1.0.0 # depends on dio: ^3.0.0
+  flutter_secure_storage: ^4.2.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,9 @@ dependencies:
   permission_handler: ^8.1.4+2
   path_provider: ^2.0.2
   tuple: ^2.0.0
+  dio: ^4.0.0
+  cookie_jar: ^3.0.1
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Using Dio, I add interceptors to attach `access token` to headers & `request token` to the cookie (using CookieManager). Also created request clients to make requesting easy -- divided into two client types: `getClient` and `getClientWithAuth`.

`getClient` is a normal request client, no authorization.
`getClientWithAuth` is a request with cookie & header pre-attached.

Both clients' response is parsed and checked for new `access token`.